### PR TITLE
Autogenerate document IDs

### DIFF
--- a/example/lib/random_operation_runner.dart
+++ b/example/lib/random_operation_runner.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:example/models/user.dart';
 import 'package:loon/loon.dart';
+import 'package:loon/utils/id.dart';
 
 enum Operations {
   hydrate,
@@ -24,7 +25,7 @@ class RandomOperationRunner {
       _logger.log('Persist $count');
 
       for (int i = 0; i < count; i++) {
-        final id = uuid.v4();
+        final id = generateId();
         UserModel.store.doc(id).create(UserModel(name: 'User $id'));
       }
     } else if (operationIndex >= 80 && operationIndex < 90) {

--- a/lib/broadcast_observer.dart
+++ b/lib/broadcast_observer.dart
@@ -1,7 +1,5 @@
 part of './loon.dart';
 
-const uuid = Uuid();
-
 /// A mixin that provides an observable interface for the access and streaming of data broadcasted from the store.
 mixin BroadcastObserver<T, S> {
   late final StreamController<T> _controller;
@@ -45,7 +43,7 @@ mixin BroadcastObserver<T, S> {
     _controllerValue = initialValue;
     _controller.add(initialValue);
 
-    _observerId = "${path}__${uuid.v4()}";
+    _observerId = "${path}__${generateId()}";
 
     Loon._instance.broadcastManager.addObserver(this, initialValue);
   }

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -86,10 +86,10 @@ class Collection<T> implements Queryable<T>, StoreReference {
         Loon._instance._isGlobalPersistenceEnabled;
   }
 
-  Document<T> doc(String id) {
+  Document<T> doc([String? id]) {
     return Document<T>(
       path,
-      id,
+      id ?? generateId(),
       fromJson: fromJson,
       toJson: toJson,
       persistorSettings: persistorSettings,

--- a/lib/loon.dart
+++ b/lib/loon.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart' hide Key;
 import 'package:loon/persistor/data_store_encrypter.dart';
-import 'package:uuid/uuid.dart';
+import 'package:loon/utils/id.dart';
 import 'dart:collection';
 import 'persistor/index.dart';
 
@@ -121,7 +121,7 @@ class Loon {
       },
     ).toList();
 
-    return List<DocumentSnapshot<T>>.from(snaps ?? []);
+    return snaps ?? [];
   }
 
   DocumentSnapshot<T> writeDocument<T>(

--- a/lib/persistor/worker/messages.dart
+++ b/lib/persistor/worker/messages.dart
@@ -1,13 +1,11 @@
 import 'dart:isolate';
 import 'package:loon/persistor/persist_payload.dart';
-import 'package:uuid/uuid.dart';
-
-const uuid = Uuid();
+import 'package:loon/utils/id.dart';
 
 abstract class Message {}
 
 abstract class MessageRequest<T extends MessageResponse> extends Message {
-  final id = uuid.v4();
+  final id = generateId();
 
   MessageRequest();
 

--- a/lib/utils/id.dart
+++ b/lib/utils/id.dart
@@ -15,7 +15,7 @@ String generateId([int size = 21]) {
   var i = 0;
 
   while (i < size) {
-    int r = _rand.nextInt(_u32); // 32 random bits → 5×6-bit chars
+    int r = _rand.nextInt(_u32); // 5×6-bit chars (30 bits used, 2 bits unused)
 
     var k = 0;
     while (k < 5 && i < size) {

--- a/lib/utils/id.dart
+++ b/lib/utils/id.dart
@@ -1,0 +1,29 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+const String _alphabet =
+    '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+final Uint8List _alphabytes = Uint8List.fromList(_alphabet.codeUnits);
+const int _u32 = 0x100000000; // 2^32
+
+final Random _rand = Random.secure();
+
+/// Generates a cryptographically secure, URL-safe random ID.
+/// Default: 21 chars ≈ 126 bits of entropy.
+String generateId([int size = 21]) {
+  final out = Uint8List(size);
+  var i = 0;
+
+  while (i < size) {
+    int r = _rand.nextInt(_u32); // 32 random bits → 5×6-bit chars
+
+    var k = 0;
+    while (k < 5 && i < size) {
+      out[i++] = _alphabytes[r & 63];
+      r >>= 6;
+      k++;
+    }
+  }
+
+  return String.fromCharCodes(out);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 5.5.0
 homepage: https://github.com/danReynolds/loon
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
   flutter: ">=1.17.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,11 +4,10 @@ version: 5.5.0
 homepage: https://github.com/danReynolds/loon
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
   flutter: ">=1.17.0"
 
 dependencies:
-  uuid: ^4.3.3
   encrypt: ^5.0.3
   flutter:
     sdk: flutter

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -2,9 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:encrypt/encrypt.dart';
 import 'package:loon/loon.dart';
-import 'package:uuid/uuid.dart';
 
-const uuid = Uuid();
 final testEncryptionKey = Key.fromSecureRandom(32);
 
 String encryptData(Json json) {


### PR DESCRIPTION
Given that this library takes some cues from Cloud Firestore, which [supports automatically generating IDs](https://firebase.google.com/docs/firestore/manage-data/add-data?_gl=1*77smsd*_up*MQ..*_ga*MTExMDU5NTExNy4xNzYyMjYyOTU2*_ga_CW55HF8NVT*czE3NjIyNjI5NTYkbzEkZzAkdDE3NjIyNjI5NTYkajYwJGwwJGgw), let's add that.