### PR TITLE
fix: write persistence files atomically

### DIFF
--- a/lib/persistor/file_persistor/file_data_store_config.dart
+++ b/lib/persistor/file_persistor/file_data_store_config.dart
@@ -14,9 +14,16 @@ import 'package:loon/persistor/data_store_resolver.dart';
 ///
 /// The `.tmp` suffix is deliberately not matched by the data store file listing
 /// (`fileRegex` in the worker), so a temp file orphaned by an interrupted write
-/// is ignored and overwritten on the next write rather than loaded as a store.
+/// is ignored and deleted before the next write to the same target rather than
+/// loaded as a store.
 Future<void> _writeFileAtomic(File file, String contents) async {
   final tmpFile = File('${file.path}.tmp');
+
+  try {
+    await tmpFile.delete();
+  } on PathNotFoundException {
+    // No stale temp file from a previous interrupted write.
+  }
 
   try {
     final raf = await tmpFile.open(mode: FileMode.writeOnly);
@@ -32,7 +39,7 @@ Future<void> _writeFileAtomic(File file, String contents) async {
     await tmpFile.rename(file.path);
   } catch (_) {
     // Best-effort cleanup for normal write failures. This will not run after a
-    // process crash; startup cleanup in the file worker handles those leftovers.
+    // process crash; the next write to this target removes the stale temp file.
     try {
       await tmpFile.delete();
     } on FileSystemException {

--- a/lib/persistor/file_persistor/file_data_store_config.dart
+++ b/lib/persistor/file_persistor/file_data_store_config.dart
@@ -18,17 +18,28 @@ import 'package:loon/persistor/data_store_resolver.dart';
 Future<void> _writeFileAtomic(File file, String contents) async {
   final tmpFile = File('${file.path}.tmp');
 
-  final raf = await tmpFile.open(mode: FileMode.writeOnly);
   try {
-    await raf.writeString(contents);
-    // Flush the data to disk before the rename so the rename can't expose an
-    // empty/partial file after a power loss.
-    await raf.flush();
-  } finally {
-    await raf.close();
-  }
+    final raf = await tmpFile.open(mode: FileMode.writeOnly);
+    try {
+      await raf.writeString(contents);
+      // Flush the data to disk before the rename so the rename can't expose an
+      // empty/partial file after a power loss.
+      await raf.flush();
+    } finally {
+      await raf.close();
+    }
 
-  await tmpFile.rename(file.path);
+    await tmpFile.rename(file.path);
+  } catch (_) {
+    // Best-effort cleanup for normal write failures. This will not run after a
+    // process crash; startup cleanup in the file worker handles those leftovers.
+    try {
+      await tmpFile.delete();
+    } on FileSystemException {
+      // Preserve the original write error if cleanup also fails.
+    }
+    rethrow;
+  }
 }
 
 class FileDataStoreConfig extends DataStoreConfig {

--- a/lib/persistor/file_persistor/file_data_store_config.dart
+++ b/lib/persistor/file_persistor/file_data_store_config.dart
@@ -4,6 +4,33 @@ import 'package:loon/loon.dart';
 import 'package:loon/persistor/data_store.dart';
 import 'package:loon/persistor/data_store_resolver.dart';
 
+/// Writes [contents] to [file] atomically: the data is written to a sibling
+/// temporary file, flushed to disk, then renamed over the target. A rename on
+/// the same filesystem is atomic, so an interrupted write (crash, OOM kill,
+/// power loss) can never leave the target torn — it always holds either the
+/// complete previous contents or the complete new contents. A plain
+/// `writeAsString` truncates the target up front, leaving a window where a
+/// crash corrupts it.
+///
+/// The `.tmp` suffix is deliberately not matched by the data store file listing
+/// (`fileRegex` in the worker), so a temp file orphaned by an interrupted write
+/// is ignored and overwritten on the next write rather than loaded as a store.
+Future<void> _writeFileAtomic(File file, String contents) async {
+  final tmpFile = File('${file.path}.tmp');
+
+  final raf = await tmpFile.open(mode: FileMode.writeOnly);
+  try {
+    await raf.writeString(contents);
+    // Flush the data to disk before the rename so the rename can't expose an
+    // empty/partial file after a power loss.
+    await raf.flush();
+  } finally {
+    await raf.close();
+  }
+
+  await tmpFile.rename(file.path);
+}
+
 class FileDataStoreConfig extends DataStoreConfig {
   FileDataStoreConfig(
     super.name, {
@@ -34,7 +61,8 @@ class FileDataStoreConfig extends DataStoreConfig {
           persist: (store) async {
             final value = jsonEncode(store.extract());
 
-            await file.writeAsString(
+            await _writeFileAtomic(
+              file,
               encrypted ? encrypter.encrypt(value) : value,
             );
           },
@@ -61,7 +89,8 @@ class FileDataStoreResolverConfig extends DataStoreResolverConfig {
               return null;
             }
           },
-          persist: (store) => file.writeAsString(jsonEncode(store.inspect())),
+          persist: (store) =>
+              _writeFileAtomic(file, jsonEncode(store.inspect())),
           delete: () async {
             try {
               await file.delete();

--- a/lib/persistor/file_persistor/file_data_store_config.dart
+++ b/lib/persistor/file_persistor/file_data_store_config.dart
@@ -14,16 +14,10 @@ import 'package:loon/persistor/data_store_resolver.dart';
 ///
 /// The `.tmp` suffix is deliberately not matched by the data store file listing
 /// (`fileRegex` in the worker), so a temp file orphaned by an interrupted write
-/// is ignored and deleted before the next write to the same target rather than
+/// is ignored and overwritten by the next write to the same target rather than
 /// loaded as a store.
 Future<void> _writeFileAtomic(File file, String contents) async {
   final tmpFile = File('${file.path}.tmp');
-
-  try {
-    await tmpFile.delete();
-  } on PathNotFoundException {
-    // No stale temp file from a previous interrupted write.
-  }
 
   try {
     final raf = await tmpFile.open(mode: FileMode.writeOnly);
@@ -39,7 +33,7 @@ Future<void> _writeFileAtomic(File file, String contents) async {
     await tmpFile.rename(file.path);
   } catch (_) {
     // Best-effort cleanup for normal write failures. This will not run after a
-    // process crash; the next write to this target removes the stale temp file.
+    // process crash; the next write to this target overwrites the stale temp.
     try {
       await tmpFile.delete();
     } on FileSystemException {

--- a/lib/persistor/file_persistor/file_persistor_worker.dart
+++ b/lib/persistor/file_persistor/file_persistor_worker.dart
@@ -9,26 +9,6 @@ import 'package:path/path.dart' as path;
 
 final fileRegex = RegExp(r'^(?!__resolver__)(\w+?)(?:.encrypted)?\.json$');
 
-Future<void> _deleteTempFiles(Directory directory) async {
-  try {
-    final tmpFiles = directory
-        .listSync()
-        .whereType<File>()
-        .where((file) => path.basename(file.path).endsWith('.tmp'));
-
-    await Future.wait(tmpFiles.map((file) async {
-      try {
-        await file.delete();
-      } on FileSystemException {
-        // Stale temp files are ignored by hydration, so cleanup should not
-        // prevent startup if a file is already gone or cannot be removed.
-      }
-    }));
-  } on PathNotFoundException {
-    return;
-  }
-}
-
 class FilePersistorWorkerConfig extends PersistorWorkerConfig {
   final Directory directory;
 
@@ -86,7 +66,6 @@ class FilePersistorWorker extends PersistorWorker<FilePersistorWorkerConfig> {
 
   @override
   init() async {
-    await _deleteTempFiles(config.directory);
     await _manager.init();
   }
 

--- a/lib/persistor/file_persistor/file_persistor_worker.dart
+++ b/lib/persistor/file_persistor/file_persistor_worker.dart
@@ -9,6 +9,26 @@ import 'package:path/path.dart' as path;
 
 final fileRegex = RegExp(r'^(?!__resolver__)(\w+?)(?:.encrypted)?\.json$');
 
+Future<void> _deleteTempFiles(Directory directory) async {
+  try {
+    final tmpFiles = directory
+        .listSync()
+        .whereType<File>()
+        .where((file) => path.basename(file.path).endsWith('.tmp'));
+
+    await Future.wait(tmpFiles.map((file) async {
+      try {
+        await file.delete();
+      } on FileSystemException {
+        // Stale temp files are ignored by hydration, so cleanup should not
+        // prevent startup if a file is already gone or cannot be removed.
+      }
+    }));
+  } on PathNotFoundException {
+    return;
+  }
+}
+
 class FilePersistorWorkerConfig extends PersistorWorkerConfig {
   final Directory directory;
 
@@ -66,6 +86,7 @@ class FilePersistorWorker extends PersistorWorker<FilePersistorWorkerConfig> {
 
   @override
   init() async {
+    await _deleteTempFiles(config.directory);
     await _manager.init();
   }
 

--- a/test/native/file_persistor_test.dart
+++ b/test/native/file_persistor_test.dart
@@ -104,5 +104,20 @@ void main() {
       expect(fileRegex.hasMatch('users.json.tmp'), false);
       expect(fileRegex.hasMatch('__store__.json.tmp'), false);
     });
+
+    test('Cleans orphaned .tmp files on startup', () async {
+      final orphanedStoreTmp = File('${loonDir.path}/users.json.tmp');
+      final orphanedResolverTmp = File('${loonDir.path}/__resolver__.json.tmp');
+      await orphanedStoreTmp.writeAsString('partial store write');
+      await orphanedResolverTmp.writeAsString('partial resolver write');
+
+      Loon.configure(
+        persistor: FilePersistor(encrypter: encrypter),
+      );
+      await Loon.hydrate();
+
+      expect(await orphanedStoreTmp.exists(), false);
+      expect(await orphanedResolverTmp.exists(), false);
+    });
   });
 }

--- a/test/native/file_persistor_test.dart
+++ b/test/native/file_persistor_test.dart
@@ -1,7 +1,13 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'package:encrypt/encrypt.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:loon/loon.dart';
+import 'package:loon/persistor/data_store_encrypter.dart';
 import 'package:loon/persistor/file_persistor/file_persistor.dart';
+import 'package:loon/persistor/file_persistor/file_persistor_worker.dart'
+    show fileRegex;
 
 // ignore: depend_on_referenced_packages
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -52,5 +58,51 @@ void main() {
       },
       factory: FilePersistor.new,
     );
+  });
+
+  group('FilePersistor durability', () {
+    final loonDir = Directory('${testDirectory.path}/loon');
+
+    // FlutterSecureStorage does not work in tests, so supply a fixed encrypter.
+    final encrypter = DataStoreEncrypter(
+      Encrypter(AES(Key.fromSecureRandom(32), mode: AESMode.cbc)),
+    );
+
+    tearDown(() async {
+      await Loon.clearAll();
+    });
+
+    test('Persists atomically, leaving no .tmp files behind', () async {
+      final synced = Completer<void>();
+      final persistor = FilePersistor(
+        persistenceThrottle: const Duration(milliseconds: 1),
+        encrypter: encrypter,
+        onSync: () {
+          if (!synced.isCompleted) synced.complete();
+        },
+      );
+      Loon.configure(persistor: persistor);
+
+      Loon.collection<Json>('users').doc('1').create({'name': 'User 1'});
+      await synced.future;
+
+      expect(await File('${loonDir.path}/__store__.json').exists(), true);
+
+      final tmpFiles = loonDir
+          .listSync()
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.tmp'))
+          .toList();
+      expect(tmpFiles, isEmpty);
+    });
+
+    test('Data store file listing ignores orphaned .tmp files', () {
+      // A temp file orphaned by an interrupted atomic write must not be picked
+      // up as a data store on the next startup.
+      expect(fileRegex.hasMatch('users.json'), true);
+      expect(fileRegex.hasMatch('users.encrypted.json'), true);
+      expect(fileRegex.hasMatch('users.json.tmp'), false);
+      expect(fileRegex.hasMatch('__store__.json.tmp'), false);
+    });
   });
 }

--- a/test/native/file_persistor_test.dart
+++ b/test/native/file_persistor_test.dart
@@ -105,16 +105,31 @@ void main() {
       expect(fileRegex.hasMatch('__store__.json.tmp'), false);
     });
 
-    test('Cleans orphaned .tmp files on startup', () async {
-      final orphanedStoreTmp = File('${loonDir.path}/users.json.tmp');
+    test('Cleans orphaned .tmp files before rewriting their targets', () async {
+      final orphanedStoreTmp = File('${loonDir.path}/custom_store.json.tmp');
       final orphanedResolverTmp = File('${loonDir.path}/__resolver__.json.tmp');
       await orphanedStoreTmp.writeAsString('partial store write');
       await orphanedResolverTmp.writeAsString('partial resolver write');
 
+      final synced = Completer<void>();
       Loon.configure(
-        persistor: FilePersistor(encrypter: encrypter),
+        persistor: FilePersistor(
+          persistenceThrottle: const Duration(milliseconds: 1),
+          encrypter: encrypter,
+          onSync: () {
+            if (!synced.isCompleted) synced.complete();
+          },
+        ),
       );
-      await Loon.hydrate();
+
+      final users = Loon.collection<Json>(
+        'users',
+        persistorSettings: PersistorSettings(
+          key: Persistor.key('custom_store'),
+        ),
+      );
+      users.doc('1').create({'name': 'User 1'});
+      await synced.future;
 
       expect(await orphanedStoreTmp.exists(), false);
       expect(await orphanedResolverTmp.exists(), false);

--- a/test/native/file_persistor_test.dart
+++ b/test/native/file_persistor_test.dart
@@ -105,7 +105,8 @@ void main() {
       expect(fileRegex.hasMatch('__store__.json.tmp'), false);
     });
 
-    test('Cleans orphaned .tmp files before rewriting their targets', () async {
+    test('Overwrites orphaned .tmp files when rewriting their targets',
+        () async {
       final orphanedStoreTmp = File('${loonDir.path}/custom_store.json.tmp');
       final orphanedResolverTmp = File('${loonDir.path}/__resolver__.json.tmp');
       await orphanedStoreTmp.writeAsString('partial store write');

--- a/test/native/file_persistor_test.dart
+++ b/test/native/file_persistor_test.dart
@@ -20,7 +20,7 @@ late Directory testDirectory;
 class MockPathProvider extends Fake
     with MockPlatformInterfaceMixin
     implements PathProviderPlatform {
-  getApplicationDocumentsDirectory() {
+  Directory getApplicationDocumentsDirectory() {
     return testDirectory;
   }
 


### PR DESCRIPTION
## Summary

`FileDataStoreConfig` persisted both data stores and the resolver index with `file.writeAsString`, which opens with `FileMode.write` — truncating the target to zero **before** writing the new contents. That leaves a window where a crash, OOM kill, or power loss corrupts the file:

```
[complete old JSON] → [empty] → [partial new JSON] → [complete new JSON]
```

On the next launch `jsonDecode` throws (and only `PathNotFoundException` is caught), so the error propagates through `Loon.hydrate` and that partition's data is lost or startup breaks. This affects the **default** persistor on mobile/desktop, and the resolver file is equally exposed (it's the path → store-name index).

## Fix

Write to a sibling temp file, flush it to disk, then `rename` over the target:

```
write users.json.tmp → flush → rename(users.json.tmp → users.json)
```

A same-filesystem `rename` is atomic, so the target always holds **either** the complete previous contents **or** the complete new contents — never a torn file. The `flush` before the rename ensures the data is durable so the rename can't expose an empty file after power loss.

### Why this is safe cross-platform

Modern Dart (3.x, which the package requires) documents that `File.rename` removes an existing destination file first, and on Windows it uses `MoveFileEx`-style replace semantics for regular files (our case — these are plain `.json` files, not symlinks). So no platform special-casing is needed.

### Orphaned temp files are harmless

The worker's data store file listing (`fileRegex`) matches only `…\.json$`, so a `users.json.tmp` orphaned by an interrupted write is **not** loaded as a store — it's simply overwritten on the next write. A test pins this.

## Scope / what this does *not* cover

This makes each file individually torn-proof. It does **not** make a multi-file sync (multiple partitions + resolver) transactionally consistent — that would need a manifest/generation pointer and is out of scope. For static persistence keys the resolver rarely changes, so this fix covers the real, common failure (a torn individual file on a process kill). SQLite/IndexedDB backends are already transactional and are unaffected.

## Test plan

- [x] `flutter test test/native --concurrency=1` — 86/86 green (the existing 42 round-trip persistor tests confirm the atomic write produces identical content)
- [x] New: asserts no `.tmp` files remain after a sync
- [x] New: asserts the data store listing ignores orphaned `.tmp` files
- [x] `flutter analyze` clean on changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQyAbe9xNjXGsaSvdhst7U)_