### PR TITLE
test: deterministic broadcast batching/ordering tests via fakeAsync

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,10 +19,10 @@ dependencies:
   sqflite_common_ffi: ^2.3.4
 
 dev_dependencies:
+  fake_async: ^1.3.3
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
 
 
 flutter:
-  

--- a/test/core/broadcast_timing_test.dart
+++ b/test/core/broadcast_timing_test.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: depend_on_referenced_packages
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:loon/loon.dart';

--- a/test/core/broadcast_timing_test.dart
+++ b/test/core/broadcast_timing_test.dart
@@ -1,0 +1,125 @@
+// ignore_for_file: depend_on_referenced_packages
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:loon/loon.dart';
+
+/// Deterministic tests for broadcast batching, coalescing, and ordering.
+///
+/// Loon schedules a broadcast on a zero-duration timer so that all writes in a
+/// single event-loop task are delivered to observers as one update. Testing
+/// that behaviour with real time is inherently racy (it depends on a real timer
+/// firing before the test's wait), which is a known source of flakiness in the
+/// suite. These tests run under [fakeAsync] instead: virtual time is advanced
+/// explicitly, so the broadcast timer and its microtask stream delivery fire
+/// deterministically before each assertion, with no dependence on wall-clock
+/// scheduling or CPU load.
+///
+/// (A dedicated file runs in its own test isolate, so the global store starts
+/// clean and these virtual-time tests are isolated from the rest of the suite.)
+
+/// Advances virtual time past the broadcast's zero-duration timer and drains
+/// the microtasks that deliver stream events.
+void _flush(FakeAsync async) {
+  async.elapse(const Duration(milliseconds: 1));
+}
+
+void _reset(FakeAsync async) {
+  Loon.unsubscribe();
+  Loon.clearAll(broadcast: false);
+  async.flushMicrotasks();
+}
+
+void main() {
+  group('Broadcast batching and coalescing', () {
+    test('Multiple writes in one task produce a single broadcast', () {
+      fakeAsync((async) {
+        _reset(async);
+        final col = Loon.collection<int>('items');
+
+        final emissions = <List<int>>[];
+        final sub = col
+            .stream()
+            .listen((snaps) => emissions.add([for (final s in snaps) s.data]));
+        _flush(async); // initial emission
+
+        col.doc('1').create(1);
+        col.doc('2').create(2);
+        col.doc('3').create(3);
+        _flush(async);
+
+        // One emission for the initial value and exactly one for the batch.
+        expect(emissions.length, 2);
+        expect(emissions.last..sort(), [1, 2, 3]);
+
+        sub.cancel();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('Create then update in one task coalesces to the final value', () {
+      fakeAsync((async) {
+        _reset(async);
+        final doc = Loon.collection<int>('items').doc('1');
+
+        final emissions = <int?>[];
+        final sub = doc.stream().listen((snap) => emissions.add(snap?.data));
+        _flush(async); // initial null
+
+        doc.create(1);
+        doc.update(2);
+        _flush(async);
+
+        // The create and update collapse into a single emission of the final value.
+        expect(emissions, [null, 2]);
+
+        sub.cancel();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('Writes in separate tasks produce separate broadcasts', () {
+      fakeAsync((async) {
+        _reset(async);
+        final doc = Loon.collection<int>('items').doc('1');
+
+        final emissions = <int?>[];
+        final sub = doc.stream().listen((snap) => emissions.add(snap?.data));
+        _flush(async); // initial null
+
+        doc.create(1);
+        _flush(async);
+        doc.update(2);
+        _flush(async);
+        doc.update(3);
+        _flush(async);
+
+        expect(emissions, [null, 1, 2, 3]);
+
+        sub.cancel();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('An unchanged update does not rebroadcast', () {
+      fakeAsync((async) {
+        _reset(async);
+        final doc = Loon.collection<int>('items').doc('1');
+
+        final emissions = <int?>[];
+        final sub = doc.stream().listen((snap) => emissions.add(snap?.data));
+        _flush(async); // initial null
+
+        doc.create(1);
+        _flush(async);
+        doc.update(1); // same value
+        _flush(async);
+
+        // No emission for the no-op update.
+        expect(emissions, [null, 1]);
+
+        sub.cancel();
+        async.flushMicrotasks();
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds **deterministic** tests for broadcast batching, coalescing, and ordering using `fakeAsync`.

Loon schedules a broadcast on a zero-duration timer so that all writes in a single event-loop task are delivered to observers as one update. Verifying that behaviour with real time is inherently racy — it depends on a real timer firing before the test's `await` — which is a known source of flakiness in the suite. These tests advance **virtual time** explicitly, so the broadcast timer and its microtask stream delivery fire deterministically before each assertion, with no dependence on wall-clock scheduling or CPU load.

## What's covered

- **Batching** — three creates in one task produce exactly one emission (initial + one batch).
- **Coalescing** — create + update in one task collapse to a single emission of the final value.
- **Per-task separation** — writes in separate tasks produce separate broadcasts.
- **No-op suppression** — an update with an unchanged value does not rebroadcast.

Each test runs inside a single `fakeAsync` zone, and the file gets its own test isolate (so the global store starts clean and these virtual-time tests are isolated from the rest of the suite). Verified deterministic across repeated runs.

## Context / scope

This is the additive half of the "fakeAsync" hardening item: **new deterministic ordering tests**. I deliberately did **not** convert the existing real-async suite to fakeAsync. Investigation showed the suite's intermittent failures aren't purely a timing race — there's a cross-test state-bleed component (resetting the global store between tests schedules a broadcast that can race the next test) that a fakeAsync conversion wouldn't cleanly fix, and a wholesale rewrite of a working suite is high-risk for a flake that's already mitigated in CI (`--concurrency=1` + re-kick). The deterministic delete+recreate-coalescing case lives with its fix in #36.

## Test plan

- [x] `flutter test test/core/broadcast_timing_test.dart` — 4 tests green; deterministic across 5+ repeated runs
- [x] `flutter analyze` clean on the new file
- [x] `flutter test test/core` — green

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQyAbe9xNjXGsaSvdhst7U)_