### PR TITLE
ci: run tests on main pushes

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -3,7 +3,10 @@ name: Run Flutter Tests
 on:
   pull_request:
     branches:
-      - main  # Adjust the target branch as needed
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Adds a `push` trigger for `main` to the Flutter test workflow, while keeping the existing `pull_request` trigger for PRs targeting `main`.

## Why

The workflow currently runs for PR updates only. After a PR is merged, the resulting commit on `main` does not start CI, so merge commits can land without a post-merge verification run.

## Verification

- `git diff --check`
